### PR TITLE
Update metadata.json to support Gnome 48

### DIFF
--- a/pipewire-airplay-toggle@craw0967.github.com/metadata.json
+++ b/pipewire-airplay-toggle@craw0967.github.com/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/craw0967/pipewire-airplay-toggle"
 }


### PR DESCRIPTION
Tested OK on Fedora 42. Might need more thorough testing but no issues so far.